### PR TITLE
trying to hint js objects

### DIFF
--- a/calcit.edn
+++ b/calcit.edn
@@ -27982,7 +27982,7 @@
               :data {
                "D" {:type :leaf, :author "root", :time 1508169432006, :text "path/join", :id "Bkg-C8IfTW"}
                "L" {:type :leaf, :author "root", :time 1508169422054, :text "js/__dirname", :id "SymRU8G6-"}
-               "T" {:type :leaf, :author "root", :time 1508169192086, :text "|app", :id "HyNKo7UfT-"}
+               "T" {:type :leaf, :author "root", :time 1508169192086, :text "\"", :id "HyNKo7UfT-", :at 1529634470561, :by "root"}
               }
              }
             }
@@ -28012,9 +28012,7 @@
            "v" {
             :type :expr, :author "root", :time 1508168348665, :id "SyrsGUMpZ"
             :data {
-             "T" {:type :leaf, :author "root", :time 1508168350222, :text ".static", :id "By4sf8zaZ"}
-             "b" {:type :leaf, :by "root", :at 1529601640969, :text "^js", :id "BJgADC8t-X"}
-             "j" {:type :leaf, :author "root", :time 1508168355477, :text "express", :id "ByFoz8za-"}
+             "T" {:type :leaf, :author "root", :time 1508168350222, :text "express/static", :id "By4sf8zaZ", :at 1529634902511, :by "root"}
              "r" {:type :leaf, :author "root", :time 1508168632460, :text "dir", :id "HkZ13zIfa-"}
             }
            }

--- a/calcit.edn
+++ b/calcit.edn
@@ -25494,6 +25494,7 @@
                       :data {
                        "T" {:type :leaf, :by "root", :at 1518364747131, :text "js/parseInt", :id "HJL3V_k0IG"}
                        "j" {:type :leaf, :by "root", :at 1518364731991, :text "port", :id "rJNSO108z"}
+                       "r" {:type :leaf, :by "root", :at 1529601361819, :text "10", :id "SJlKITUKW7"}
                       }
                      }
                     }
@@ -28012,6 +28013,7 @@
             :type :expr, :author "root", :time 1508168348665, :id "SyrsGUMpZ"
             :data {
              "T" {:type :leaf, :author "root", :time 1508168350222, :text ".static", :id "By4sf8zaZ"}
+             "b" {:type :leaf, :by "root", :at 1529601640969, :text "^js", :id "BJgADC8t-X"}
              "j" {:type :leaf, :author "root", :time 1508168355477, :text "express", :id "ByFoz8za-"}
              "r" {:type :leaf, :author "root", :time 1508168632460, :text "dir", :id "HkZ13zIfa-"}
             }
@@ -28325,6 +28327,7 @@
                     :type :expr, :author "SJhrjuzlG", :time 1512708380784, :id "B1HmY9Dbz"
                     :data {
                      "T" {:type :leaf, :author "SJhrjuzlG", :time 1512708384809, :text ".on", :id "B1HmY9Dbzleaf"}
+                     "b" {:type :leaf, :by "root", :at 1529601918674, :text "^js", :id "HygSKJwKWQ"}
                      "j" {:type :leaf, :author "SJhrjuzlG", :time 1512708389438, :text "watcher", :id "HyqXK5vZf"}
                      "r" {:type :leaf, :author "SJhrjuzlG", :time 1512708547064, :text "|changed", :id "SyCXK5vbz"}
                      "v" {
@@ -28727,6 +28730,7 @@
                   :type :expr, :author "root", :time 1511284250359, :id "rJGm0AbxM"
                   :data {
                    "T" {:type :leaf, :author "root", :time 1511284253291, :text ".-Server", :id "Bk4ZXRC-xz"}
+                   "b" {:type :leaf, :by "root", :at 1529601690048, :text "^js", :id "Skgo0IY-Q"}
                    "j" {:type :leaf, :author "root", :time 1511284253844, :text "ws", :id "ByNrXC0WxG"}
                   }
                  }
@@ -28759,6 +28763,7 @@
               :type :expr, :time 1504777570689, :id "HJZU11_Ivz"
               :data {
                "T" {:type :leaf, :author "root", :time 1504777570689, :text ".on", :id "r1PCLnjF435b"}
+               "b" {:type :leaf, :by "root", :at 1529601890036, :text "^js", :id "SyuPkvKZQ"}
                "j" {:type :leaf, :author "root", :time 1504777570689, :text "wss", :id "HyuAUnjt42qZ"}
                "r" {:type :leaf, :author "root", :time 1504777570689, :text "|connection", :id "HyKCI3oKV3cb"}
                "v" {
@@ -28837,6 +28842,7 @@
                     :type :expr, :time 1504777570689, :id "r1Sgv3iYEnq-"
                     :data {
                      "T" {:type :leaf, :author "root", :time 1504777570689, :text ".on", :id "H1LeDhjKV25b"}
+                     "b" {:type :leaf, :by "root", :at 1529601936927, :text "^js", :id "rklw9yDtWm"}
                      "j" {:type :leaf, :author "root", :time 1504777570689, :text "socket", :id "ryveDhjFN2cb"}
                      "r" {:type :leaf, :author "root", :time 1504777570689, :text "|message", :id "HyuxD2iKNn5W"}
                      "v" {
@@ -28904,6 +28910,7 @@
                     :type :expr, :time 1504777570689, :id "B1xfw3jFEn5b"
                     :data {
                      "T" {:type :leaf, :author "root", :time 1504777570689, :text ".on", :id "ByZfDhjt425-"}
+                     "b" {:type :leaf, :by "root", :at 1529601939368, :text "^js", :id "H1l55kDFb7"}
                      "j" {:type :leaf, :author "root", :time 1504777570689, :text "socket", :id "ryzfD3oYE39-"}
                      "r" {:type :leaf, :author "root", :time 1504777570689, :text "|close", :id "HJQfvnoKNhc-"}
                      "v" {
@@ -50941,6 +50948,7 @@
                    "r" {:type :leaf, :author "root", :time 1504777570689, :text "|port", :id "HkabVhit42cb"}
                   }
                  }
+                 "r" {:type :leaf, :by "root", :at 1529601374835, :text "10", :id "BJeHDa8K-7"}
                 }
                }
               }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calcit-editor",
-  "version": "0.3.47",
+  "version": "0.3.48",
   "description": "Cirru Calcit Editor",
   "bin": {
     "calcit-editor": "dist/server.js",
@@ -22,7 +22,7 @@
   "license": "MIT",
   "devDependencies": {
     "http-server": "^0.11.1",
-    "shadow-cljs": "^2.4.7",
+    "shadow-cljs": "^2.4.8",
     "source-map-support": "^0.5.6"
   },
   "dependencies": {

--- a/src/app/repl.cljs
+++ b/src/app/repl.cljs
@@ -10,7 +10,7 @@
   (println)
   (let [client (.createConnection
                 net
-                (clj->js {:port (js/parseInt port)})
+                (clj->js {:port (js/parseInt port 10)})
                 (fn [] (println "Socket REPL created!") (dispatch! :repl/start nil)))]
     (reset! *repl-instance client)
     (.on client "data" (fn [data] (dispatch! :repl/log (.toString data))))

--- a/src/app/server.cljs
+++ b/src/app/server.cljs
@@ -79,8 +79,8 @@
   (js/setTimeout render-loop! 20))
 
 (defn serve-app! [port]
-  (let [app (express), dir (path/join js/__dirname "app"), file-port (+ 100 port)]
-    (.use app "/" (.static ^js express dir) (serve-index dir (clj->js {:icons true})))
+  (let [app (express), dir (path/join js/__dirname ""), file-port (+ 100 port)]
+    (.use app "/" (express/static dir) (serve-index dir (clj->js {:icons true})))
     (.listen app file-port)
     (println
      (str "Serving local editor at " (.blue chalk (str "http://localhost:" file-port))))))

--- a/src/app/server.cljs
+++ b/src/app/server.cljs
@@ -79,8 +79,8 @@
   (js/setTimeout render-loop! 20))
 
 (defn serve-app! [port]
-  (let [app (express), dir (path/join js/__dirname ""), file-port (+ 100 port)]
-    (.use app "/" (.static express dir) (serve-index dir (clj->js {:icons true})))
+  (let [app (express), dir (path/join js/__dirname "app"), file-port (+ 100 port)]
+    (.use app "/" (.static ^js express dir) (serve-index dir (clj->js {:icons true})))
     (.listen app file-port)
     (println
      (str "Serving local editor at " (.blue chalk (str "http://localhost:" file-port))))))
@@ -95,7 +95,7 @@
         (fn [error watcher]
           (if (some? error)
             (.log js/console error)
-            (.on watcher "changed" (fn [filepath] (on-file-change!))))))))))
+            (.on ^js watcher "changed" (fn [filepath] (on-file-change!))))))))))
 
 (defn start-server! [configs]
   (run-server! #(dispatch! %1 %2 %3) (:port configs))

--- a/src/app/service.cljs
+++ b/src/app/service.cljs
@@ -31,9 +31,10 @@
   (pick-port!
    port
    (fn [unoccupied-port]
-     (let [WebSocketServer (.-Server ws)
+     (let [WebSocketServer (.-Server ^js ws)
            wss (new WebSocketServer (js-obj "port" unoccupied-port))]
        (.on
+        ^js
         wss
         "connection"
         (fn [socket]
@@ -42,12 +43,14 @@
             (swap! *registry assoc sid socket)
             (println (.gray chalk (str "client connected: " sid)))
             (.on
+             ^js
              socket
              "message"
              (fn [rawData]
                (let [action (reader/read-string rawData), [op op-data] action]
                  (on-action! op op-data sid))))
             (.on
+             ^js
              socket
              "close"
              (fn []

--- a/src/app/util/env.cljs
+++ b/src/app/util/env.cljs
@@ -5,7 +5,7 @@
 
 (defn pick-configs [configs]
   (let [cli-port (if (some? (aget js/process.env "port"))
-                   (js/parseInt (aget js/process.env "port")))
+                   (js/parseInt (aget js/process.env "port") 10))
         cli-op (aget js/process.env "op")
         cli-extension (aget js/process.env "extension")
         result (-> configs

--- a/yarn.lock
+++ b/yarn.lock
@@ -1566,9 +1566,9 @@ shadow-cljs-jar@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.1.2.tgz#88664fae5957a7c21554e1a33476f1c475162c92"
 
-shadow-cljs@^2.4.7:
-  version "2.4.7"
-  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.4.7.tgz#f6e1c035880e1cfeee559b067e42991ce60fefab"
+shadow-cljs@^2.4.8:
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.4.8.tgz#ce8ab48550b94b29b74dbb8f198bc948c52c71c2"
   dependencies:
     babel-core "^6.26.0"
     babel-preset-env "^1.6.0"


### PR DESCRIPTION
`express` is used as a namespace. `express/static` is a safer way of calling it. Besides, `shadow-cljs@2.4.8` added special support for such case.
