### PR TITLE
Add ns field in RPEL page

### DIFF
--- a/calcit.edn
+++ b/calcit.edn
@@ -22058,14 +22058,21 @@
                   :type :expr, :by "root", :at 1518364442241, :id "H1ZzQvy0Uz"
                   :data {
                    "T" {:type :leaf, :by "root", :at 1518364448793, :text ":code", :id "H1ZzQvy0Uzleaf"}
-                   "j" {:type :leaf, :by "root", :at 1518364449729, :text "|", :id "S1mYXD108M"}
+                   "j" {:type :leaf, :by "S1lNv50FW", :at 1551891700764, :text "\"", :id "S1mYXD108M"}
                   }
                  }
                  "v" {
                   :type :expr, :by "root", :at 1518611912098, :id "rkxlR6ibDz"
                   :data {
                    "T" {:type :leaf, :by "root", :at 1518611915060, :text ":build-id", :id "rkxlR6ibDzleaf"}
-                   "j" {:type :leaf, :by "root", :at 1527699962166, :text "|client", :id "S1MQCasZDf"}
+                   "j" {:type :leaf, :by "S1lNv50FW", :at 1551891702562, :text "\"client", :id "S1MQCasZDf"}
+                  }
+                 }
+                 "x" {
+                  :type :expr, :by "S1lNv50FW", :at 1551891703503, :id "Wrj4OzzdJR"
+                  :data {
+                   "T" {:type :leaf, :by "S1lNv50FW", :at 1551891760875, :text ":ns", :id "Wrj4OzzdJRleaf"}
+                   "j" {:type :leaf, :by "S1lNv50FW", :at 1551891708719, :text "\"cljs.user", :id "RyGqqIKDnT"}
                   }
                  }
                 }
@@ -22150,6 +22157,99 @@
                    "T" {:type :leaf, :by "root", :at 1518365242640, :text "{}", :id "BJfZSqkRUM"}
                   }
                  }
+                 "n" {
+                  :type :expr, :by "S1lNv50FW", :at 1551893075904, :id "raRSLzVuaz"
+                  :data {
+                   "T" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text "input", :id "Du12L92YJ2"}
+                   "j" {
+                    :type :expr, :by "S1lNv50FW", :at 1551893075904, :id "xkp6L-lRPl"
+                    :data {
+                     "T" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text "{}", :id "bEbSccOTyT"}
+                     "j" {
+                      :type :expr, :by "S1lNv50FW", :at 1551893075904, :id "Tz64mGzckG"
+                      :data {
+                       "T" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text ":style", :id "xWujGpQTqD"}
+                       "j" {
+                        :type :expr, :by "S1lNv50FW", :at 1551893075904, :id "kEybmlMsvo"
+                        :data {
+                         "T" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text "merge", :id "X7REbGwr0R"}
+                         "j" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text "style/input", :id "YC7QcsGz80"}
+                         "r" {
+                          :type :expr, :by "S1lNv50FW", :at 1551893075904, :id "289hGzCjo1"
+                          :data {
+                           "T" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text "{}", :id "D7L4y-bwOH"}
+                           "j" {
+                            :type :expr, :by "S1lNv50FW", :at 1551893075904, :id "3PaiLOc8EO"
+                            :data {
+                             "T" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text ":width", :id "WWImRQnC3l"}
+                             "j" {:type :leaf, :by "S1lNv50FW", :at 1551893097488, :text "160", :id "Vy8nvReE3N"}
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "S1lNv50FW", :at 1551893075904, :id "W4XQv0fs2E8"
+                      :data {
+                       "T" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text ":value", :id "rEw8gAOBSGm"}
+                       "j" {
+                        :type :expr, :by "S1lNv50FW", :at 1551893075904, :id "0rUXwJxbOWg"
+                        :data {
+                         "T" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text ":ns", :id "gcUD3DF67FM"}
+                         "j" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text "state", :id "IYiD9R6zOSz"}
+                        }
+                       }
+                      }
+                     }
+                     "v" {
+                      :type :expr, :by "S1lNv50FW", :at 1551893075904, :id "DGmUs9VK2lc"
+                      :data {
+                       "T" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text ":on-input", :id "Nn634dkeMMW"}
+                       "j" {
+                        :type :expr, :by "S1lNv50FW", :at 1551893075904, :id "uEahEI5b0-O"
+                        :data {
+                         "T" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text "mutation->", :id "6M1GLQyVGoi"}
+                         "j" {
+                          :type :expr, :by "S1lNv50FW", :at 1551893075904, :id "Ys5EjrQGoPF"
+                          :data {
+                           "T" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text "assoc", :id "NpX87FnCis1"}
+                           "j" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text "state", :id "ZeDa4Vd6R_v"}
+                           "r" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text ":ns", :id "948gfR114Uk"}
+                           "v" {
+                            :type :expr, :by "S1lNv50FW", :at 1551893075904, :id "Jvr5nH4eOHU"
+                            :data {
+                             "T" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text ":value", :id "jHIpQ31KN8s"}
+                             "j" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text "%e", :id "AFhM-ysw7ea"}
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                     "x" {
+                      :type :expr, :by "S1lNv50FW", :at 1551893075904, :id "FDH2lXTQ1DZ"
+                      :data {
+                       "T" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text ":placeholder", :id "6GJVnQiBYNf"}
+                       "j" {:type :leaf, :by "S1lNv50FW", :at 1551893075904, :text "\"ns", :id "id9pc-wW4_Q"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                 "p" {
+                  :type :expr, :by "S1lNv50FW", :at 1551893089400, :id "ugnlZOHdN3"
+                  :data {
+                   "T" {:type :leaf, :by "S1lNv50FW", :at 1551893089400, :text "=<", :id "RLgk8UtBf_"}
+                   "j" {:type :leaf, :by "S1lNv50FW", :at 1551893089400, :text "8", :id "xYko2vNH7M"}
+                   "r" {:type :leaf, :by "S1lNv50FW", :at 1551893089400, :text "nil", :id "sY2SnDSmA8"}
+                  }
+                 }
                  "r" {
                   :type :expr, :by "root", :at 1518365243182, :id "ryGQrc1AIG"
                   :data {
@@ -22175,7 +22275,7 @@
                             :type :expr, :by "root", :at 1518365785212, :id "BJXWDhJ0Iz"
                             :data {
                              "T" {:type :leaf, :by "root", :at 1518365786166, :text ":width", :id "r1MbPnyRLz"}
-                             "j" {:type :leaf, :by "root", :at 1518365795675, :text "400", :id "rJEGvhJC8M"}
+                             "j" {:type :leaf, :by "S1lNv50FW", :at 1551893082844, :text "320", :id "rJEGvhJC8M"}
                             }
                            }
                           }
@@ -22264,10 +22364,35 @@
                              "T" {:type :leaf, :by "root", :at 1518411106212, :text "d!", :id "HklNwacRUMleaf"}
                              "j" {:type :leaf, :by "root", :at 1518411110023, :text ":effect/send-code", :id "HyeCv6qAUG"}
                              "r" {
-                              :type :expr, :by "S1lNv50FW", :at 1551808559078, :id "MGFqd4bMmF"
+                              :type :expr, :by "S1lNv50FW", :at 1551892355158, :id "LWVCIKtSHx"
                               :data {
-                               "T" {:type :leaf, :by "S1lNv50FW", :at 1551808559078, :text ":code", :id "fg_Ew-EovN"}
-                               "j" {:type :leaf, :by "S1lNv50FW", :at 1551808559078, :text "state", :id "Vw_1BuTY-_"}
+                               "D" {:type :leaf, :by "S1lNv50FW", :at 1551892355671, :text "{}", :id "8YvhdYaQsk"}
+                               "T" {
+                                :type :expr, :by "S1lNv50FW", :at 1551892357315, :id "vxKr6qUElr"
+                                :data {
+                                 "D" {:type :leaf, :by "S1lNv50FW", :at 1551892358128, :text ":code", :id "j9Z_SDuR8"}
+                                 "T" {
+                                  :type :expr, :by "S1lNv50FW", :at 1551808559078, :id "MGFqd4bMmF"
+                                  :data {
+                                   "T" {:type :leaf, :by "S1lNv50FW", :at 1551808559078, :text ":code", :id "fg_Ew-EovN"}
+                                   "j" {:type :leaf, :by "S1lNv50FW", :at 1551808559078, :text "state", :id "Vw_1BuTY-_"}
+                                  }
+                                 }
+                                }
+                               }
+                               "j" {
+                                :type :expr, :by "S1lNv50FW", :at 1551892358828, :id "TUhRpcZaoU"
+                                :data {
+                                 "T" {:type :leaf, :by "S1lNv50FW", :at 1551892359479, :text ":ns", :id "TUhRpcZaoUleaf"}
+                                 "j" {
+                                  :type :expr, :by "S1lNv50FW", :at 1551892360114, :id "y4v0N61B3o"
+                                  :data {
+                                   "T" {:type :leaf, :by "S1lNv50FW", :at 1551892360607, :text ":ns", :id "eHh_xerz3"}
+                                   "j" {:type :leaf, :by "S1lNv50FW", :at 1551892361425, :text "state", :id "eH76Q1u3oL"}
+                                  }
+                                 }
+                                }
+                               }
                               }
                              }
                             }
@@ -22282,7 +22407,7 @@
                       :type :expr, :by "root", :at 1518368179502, :id "S1ljnHe0Lf"
                       :data {
                        "T" {:type :leaf, :by "root", :at 1518368184351, :text ":placeholder", :id "S1ljnHe0Lfleaf"}
-                       "j" {:type :leaf, :by "root", :at 1518368198259, :text "|Clojure(Script) code to run", :id "SJb6SeAIM"}
+                       "j" {:type :leaf, :by "S1lNv50FW", :at 1551891793949, :text "\"Clojure(Script) code to run", :id "SJb6SeAIM"}
                       }
                      }
                     }
@@ -22322,18 +22447,43 @@
                          "T" {:type :leaf, :by "root", :at 1518365301304, :text "action->", :id "BJxqO9kAIf"}
                          "j" {:type :leaf, :by "root", :at 1518365339227, :text ":effect/send-code", :id "ryR_q1A8M"}
                          "r" {
-                          :type :expr, :by "root", :at 1518411686212, :id "BJlCi1sC8f"
+                          :type :expr, :by "S1lNv50FW", :at 1551891866178, :id "CVcE5iYDvi"
                           :data {
-                           "D" {:type :leaf, :by "root", :at 1518411690022, :text "str", :id "rJGAjys0LM"}
-                           "L" {:type :leaf, :by "root", :at 1518411693328, :text "|(println ", :id "SyeM2yiALM"}
+                           "D" {:type :leaf, :by "S1lNv50FW", :at 1551891866767, :text "{}", :id "lMVITAV2L8"}
                            "T" {
-                            :type :expr, :by "root", :at 1518365349654, :id "HkRo9JRUf"
+                            :type :expr, :by "S1lNv50FW", :at 1551891867442, :id "sckayrW10B"
                             :data {
-                             "T" {:type :leaf, :by "root", :at 1518365352071, :text ":code", :id "rysic1RUz"}
-                             "j" {:type :leaf, :by "root", :at 1518365352660, :text "state", :id "SJQxhqJ08f"}
+                             "D" {:type :leaf, :by "S1lNv50FW", :at 1551891868363, :text ":code", :id "I0K_SnkHe"}
+                             "T" {
+                              :type :expr, :by "root", :at 1518411686212, :id "BJlCi1sC8f"
+                              :data {
+                               "D" {:type :leaf, :by "root", :at 1518411690022, :text "str", :id "rJGAjys0LM"}
+                               "L" {:type :leaf, :by "S1lNv50FW", :at 1551892293843, :text "\"(println ", :id "SyeM2yiALM"}
+                               "T" {
+                                :type :expr, :by "root", :at 1518365349654, :id "HkRo9JRUf"
+                                :data {
+                                 "T" {:type :leaf, :by "root", :at 1518365352071, :text ":code", :id "rysic1RUz"}
+                                 "j" {:type :leaf, :by "root", :at 1518365352660, :text "state", :id "SJQxhqJ08f"}
+                                }
+                               }
+                               "j" {:type :leaf, :by "root", :at 1518411694949, :text "|)", :id "H1xL3JiAUz"}
+                              }
+                             }
                             }
                            }
-                           "j" {:type :leaf, :by "root", :at 1518411694949, :text "|)", :id "H1xL3JiAUz"}
+                           "j" {
+                            :type :expr, :by "S1lNv50FW", :at 1551891868742, :id "JpbON5r6Br"
+                            :data {
+                             "T" {:type :leaf, :by "S1lNv50FW", :at 1551891869684, :text ":ns", :id "JpbON5r6Brleaf"}
+                             "j" {
+                              :type :expr, :by "S1lNv50FW", :at 1551891873412, :id "MZIB-ykg56"
+                              :data {
+                               "T" {:type :leaf, :by "S1lNv50FW", :at 1551891873772, :text ":ns", :id "lVAe97CrW"}
+                               "j" {:type :leaf, :by "S1lNv50FW", :at 1551891875398, :text "state", :id "qaNFINtJJj"}
+                              }
+                             }
+                            }
+                           }
                           }
                          }
                         }
@@ -22346,7 +22496,7 @@
                     :type :expr, :by "root", :at 1518365358621, :id "S1wn51R8f"
                     :data {
                      "T" {:type :leaf, :by "root", :at 1518365359528, :text "<>", :id "S1wn51R8fleaf"}
-                     "j" {:type :leaf, :by "root", :at 1518365363829, :text "|Run", :id "Skxu2qkCIG"}
+                     "j" {:type :leaf, :by "S1lNv50FW", :at 1551891920540, :text "\"Run", :id "Skxu2qkCIG"}
                     }
                    }
                   }
@@ -22403,7 +22553,7 @@
                   :type :expr, :by "root", :at 1518365837497, :id "BylS53JCLz"
                   :data {
                    "T" {:type :leaf, :by "root", :at 1518365838067, :text "=<", :id "BylS53JCLzleaf"}
-                   "j" {:type :leaf, :by "root", :at 1518365838485, :text "8", :id "SJbUqny0UM"}
+                   "j" {:type :leaf, :by "S1lNv50FW", :at 1551893124886, :text "48", :id "SJbUqny0UM"}
                    "r" {:type :leaf, :by "root", :at 1518365839053, :text "nil", :id "S1vq3JRLf"}
                   }
                  }
@@ -22485,7 +22635,7 @@
                       :type :expr, :by "root", :at 1518368179502, :id "S1ljnHe0Lf"
                       :data {
                        "T" {:type :leaf, :by "root", :at 1518368184351, :text ":placeholder", :id "S1ljnHe0Lfleaf"}
-                       "j" {:type :leaf, :by "root", :at 1518611957743, :text "|build-id", :id "SJb6SeAIM"}
+                       "j" {:type :leaf, :by "S1lNv50FW", :at 1551891770300, :text "\"build-id", :id "SJb6SeAIM"}
                       }
                      }
                     }
@@ -22547,7 +22697,7 @@
                     :type :expr, :by "root", :at 1518365358621, :id "S1wn51R8f"
                     :data {
                      "T" {:type :leaf, :by "root", :at 1518365359528, :text "<>", :id "S1wn51R8fleaf"}
-                     "j" {:type :leaf, :by "root", :at 1518455146247, :text "|Connect to runtime", :id "Skxu2qkCIG"}
+                     "j" {:type :leaf, :by "S1lNv50FW", :at 1551893146940, :text "\"Connect runtime", :id "Skxu2qkCIG"}
                     }
                    }
                   }
@@ -22946,7 +23096,7 @@
                   :type :expr, :by "root", :at 1518362927713, :id "HJu4byRIz"
                   :data {
                    "T" {:type :leaf, :by "root", :at 1518362928776, :text "<>", :id "HJu4byRIzleaf"}
-                   "j" {:type :leaf, :by "root", :at 1518362956669, :text "|Try to connect", :id "rJZKE-1RLz"}
+                   "j" {:type :leaf, :by "S1lNv50FW", :at 1551891787454, :text "\"Try to connect", :id "rJZKE-1RLz"}
                   }
                  }
                 }
@@ -27096,11 +27246,36 @@
           :data {
            "T" {:type :leaf, :by "root", :at 1518366983824, :text "send-raw-code!", :id "H1kM-l0LGleaf"}
            "j" {
-            :type :expr, :by "root", :at 1518367075397, :id "HkxsD-x0IG"
+            :type :expr, :by "S1lNv50FW", :at 1551892025176, :id "7TJdzOEx-X"
             :data {
-             "D" {:type :leaf, :by "root", :at 1518367076172, :text "str", :id "BknvWeCLG"}
-             "T" {:type :leaf, :by "root", :at 1518366985570, :text "code", :id "r1-G-l0Lf"}
-             "j" {:type :leaf, :by "root", :at 1518367079416, :text "\\newline", :id "ryawWg0Lz"}
+             "D" {:type :leaf, :by "S1lNv50FW", :at 1551892025777, :text "{}", :id "yZr8Npqy5O"}
+             "T" {
+              :type :expr, :by "S1lNv50FW", :at 1551892026367, :id "tlWeXv78Pb"
+              :data {
+               "D" {:type :leaf, :by "S1lNv50FW", :at 1551892027572, :text ":code", :id "OFDxoB4TG"}
+               "T" {
+                :type :expr, :by "root", :at 1518367075397, :id "HkxsD-x0IG"
+                :data {
+                 "D" {:type :leaf, :by "root", :at 1518367076172, :text "str", :id "BknvWeCLG"}
+                 "T" {:type :leaf, :by "root", :at 1518366985570, :text "code", :id "r1-G-l0Lf"}
+                 "j" {:type :leaf, :by "root", :at 1518367079416, :text "\\newline", :id "ryawWg0Lz"}
+                }
+               }
+              }
+             }
+             "j" {
+              :type :expr, :by "S1lNv50FW", :at 1551892028156, :id "hA2CRidsL-"
+              :data {
+               "T" {:type :leaf, :by "S1lNv50FW", :at 1551892028779, :text ":ns", :id "hA2CRidsL-leaf"}
+               "j" {
+                :type :expr, :by "S1lNv50FW", :at 1551892067945, :id "fDb3OiLBZC"
+                :data {
+                 "T" {:type :leaf, :by "S1lNv50FW", :at 1551892068466, :text ":ns", :id "EiVHwPDF5o"}
+                 "j" {:type :leaf, :by "S1lNv50FW", :at 1551892070189, :text "bookmark", :id "I3WDUZxjzj"}
+                }
+               }
+              }
+             }
             }
            }
            "r" {:type :leaf, :by "root", :at 1518366987456, :text "dispatch!", :id "HJWzfbxAUz"}
@@ -27426,7 +27601,7 @@
        "r" {
         :type :expr, :by "root", :at 1518283057868, :id "SJm5Nts2Lf"
         :data {
-         "D" {:type :leaf, :by "root", :at 1518284183794, :text "code", :id "SyJjpjnUG"}
+         "D" {:type :leaf, :by "S1lNv50FW", :at 1551891855587, :text "op-data", :id "SyJjpjnUG"}
          "T" {:type :leaf, :by "root", :at 1518284182029, :text "dispatch!", :id "r1xh5ps28z"}
         }
        }
@@ -27437,6 +27612,32 @@
          "j" {
           :type :expr, :by "root", :at 1518284928738, :id "S1gFtxh38z"
           :data {
+           "D" {
+            :type :expr, :by "S1lNv50FW", :at 1551891843148, :id "R8GiYeL_M"
+            :data {
+             "T" {:type :leaf, :by "S1lNv50FW", :at 1551891844712, :text "code", :id "R8GiYeL_Mleaf"}
+             "j" {
+              :type :expr, :by "S1lNv50FW", :at 1551891844923, :id "PhvmKzKld2"
+              :data {
+               "T" {:type :leaf, :by "S1lNv50FW", :at 1551891845561, :text ":code", :id "JPmfqWKuQt"}
+               "j" {:type :leaf, :by "S1lNv50FW", :at 1551891846892, :text "op-data", :id "vP8enhazKU"}
+              }
+             }
+            }
+           }
+           "L" {
+            :type :expr, :by "S1lNv50FW", :at 1551891848020, :id "o-UQkXd1KA"
+            :data {
+             "T" {:type :leaf, :by "S1lNv50FW", :at 1551891851548, :text "eval-ns", :id "o-UQkXd1KAleaf"}
+             "j" {
+              :type :expr, :by "S1lNv50FW", :at 1551891851770, :id "n4hmBS0OLJ"
+              :data {
+               "T" {:type :leaf, :by "S1lNv50FW", :at 1551891852232, :text ":ns", :id "DTQnEAhGNv"}
+               "j" {:type :leaf, :by "S1lNv50FW", :at 1551891853277, :text "op-data", :id "wV7iIzTrDU"}
+              }
+             }
+            }
+           }
            "T" {
             :type :expr, :by "root", :at 1518284928992, :id "SybFYxh28f"
             :data {
@@ -27467,7 +27668,7 @@
                "T" {:type :leaf, :by "S1lNv50FW", :at 1551723054583, :text ".eval", :id "L8hDbjFWZleaf"}
                "j" {:type :leaf, :by "S1lNv50FW", :at 1551723055809, :text "client", :id "mAkM466k5q"}
                "r" {:type :leaf, :by "S1lNv50FW", :at 1551723887577, :text "code", :id "f5C3gK_uP"}
-               "v" {:type :leaf, :by "S1lNv50FW", :at 1551723682138, :text "\"app.main", :id "nd8kHcPg3B"}
+               "v" {:type :leaf, :by "S1lNv50FW", :at 1551891860483, :text "eval-ns", :id "nd8kHcPg3B"}
                "x" {:type :leaf, :by "S1lNv50FW", :at 1551723848137, :text "@*repl-session", :id "dCo6hFgXy1"}
                "y" {
                 :type :expr, :by "S1lNv50FW", :at 1551808604465, :id "wzpgcuOZ7"

--- a/calcit.edn
+++ b/calcit.edn
@@ -22836,6 +22836,13 @@
                            "j" {:type :leaf, :by "S1lNv50FW", :at 1551809143371, :text "\"16px 0", :id "OR3qlcV2L"}
                           }
                          }
+                         "yx" {
+                          :type :expr, :by "S1lNv50FW", :at 1551893886718, :id "sik7W98ng"
+                          :data {
+                           "T" {:type :leaf, :by "S1lNv50FW", :at 1551893890572, :text ":user-select", :id "sik7W98ngleaf"}
+                           "j" {:type :leaf, :by "S1lNv50FW", :at 1551893892590, :text ":text", :id "1D8nUibA8R"}
+                          }
+                         }
                         }
                        }
                       }

--- a/calcit.edn
+++ b/calcit.edn
@@ -20451,7 +20451,7 @@
                   :type :expr, :by "root", :at 1517755496417, :id "S1bconcNIf"
                   :data {
                    "T" {:type :leaf, :by "root", :at 1517755502050, :text ":line-height", :id "rk-xdhcNIzleaf"}
-                   "j" {:type :leaf, :by "root", :at 1517755504214, :text "|1.5em", :id "SJSIu2qN8M"}
+                   "j" {:type :leaf, :by "S1lNv50FW", :at 1551895439390, :text "\"1.5em", :id "SJSIu2qN8M"}
                   }
                  }
                 }
@@ -20504,16 +20504,22 @@
                "j" {:type :leaf, :by "root", :at 1517755430094, :text ":hidden", :id "BJ42m39ELG"}
               }
              }
+             "yT" {
+              :type :expr, :by "S1lNv50FW", :at 1551895647637, :id "UFCsyuX-5K"
+              :data {
+               "T" {:type :leaf, :by "S1lNv50FW", :at 1551895647637, :text ":text-overflow", :id "SeE_t_pu0C"}
+               "j" {:type :leaf, :by "S1lNv50FW", :at 1551895647637, :text ":ellipsis", :id "VJIbUZJBAY"}
+              }
+             }
+             "yj" {
+              :type :expr, :by "S1lNv50FW", :at 1551895650826, :id "X6hsdctFho"
+              :data {
+               "T" {:type :leaf, :by "S1lNv50FW", :at 1551895650826, :text ":max-width", :id "giWETJ_81K"}
+               "j" {:type :leaf, :by "S1lNv50FW", :at 1551895730702, :text "480", :id "zRuNzfHXrt"}
+              }
+             }
             }
            }
-          }
-         }
-         "t" {
-          :type :expr, :by "root", :at 1517755022861, :id "HyqW35V8M"
-          :data {
-           "T" {:type :leaf, :by "root", :at 1517755024733, :text "=<", :id "rJPcc94UMleaf"}
-           "j" {:type :leaf, :by "root", :at 1517755031985, :text "8", :id "Hkgt5qqNIz"}
-           "r" {:type :leaf, :by "root", :at 1517755026232, :text "nil", :id "SyZcqccE8z"}
           }
          }
          "v" {
@@ -20551,6 +20557,13 @@
                   :data {
                    "T" {:type :leaf, :by "root", :at 1517755361600, :text ":cursor", :id "r1gO1n5VLMleaf"}
                    "j" {:type :leaf, :by "root", :at 1517755363884, :text ":pointer", :id "rkxcyhcVUM"}
+                  }
+                 }
+                 "v" {
+                  :type :expr, :by "S1lNv50FW", :at 1551895590858, :id "Z6FFyhVgy9"
+                  :data {
+                   "T" {:type :leaf, :by "S1lNv50FW", :at 1551895593786, :text ":margin-left", :id "Z6FFyhVgy9leaf"}
+                   "j" {:type :leaf, :by "S1lNv50FW", :at 1551895595763, :text "8", :id "5TzlAp9VwA"}
                   }
                  }
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calcit-editor",
-  "version": "0.4.4-a2",
+  "version": "0.4.4-a3",
   "description": "Cirru Calcit Editor",
   "bin": {
     "calcit-editor": "dist/server.js",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "chalk": "^2.4.2",
-    "dayjs": "^1.8.8",
+    "dayjs": "^1.8.9",
     "express": "^4.16.4",
     "gaze": "^1.1.3",
     "latest-version": "^4.0.0",
@@ -40,6 +40,6 @@
     "nrepl-client": "^0.3.0",
     "serve-index": "^1.9.1",
     "shortid": "^2.2.14",
-    "ws": "^6.1.4"
+    "ws": "^6.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calcit-editor",
-  "version": "0.4.4-a1",
+  "version": "0.4.4-a2",
   "description": "Cirru Calcit Editor",
   "bin": {
     "calcit-editor": "dist/server.js",

--- a/src/app/comp/peek_def.cljs
+++ b/src/app/comp/peek_def.cljs
@@ -22,8 +22,9 @@
    (stringify-s-expr (tree->cirru simple-expr))
    {:font-family "Source Code Pro, Iosevka,Consolas,monospace",
     :white-space :nowrap,
-    :overflow :hidden})
-  (=< 8 nil)
+    :overflow :hidden,
+    :text-overflow :ellipsis,
+    :max-width 480})
   (span
-   {:on-click (action-> :writer/hide-peek nil), :style {:cursor :pointer}}
+   {:on-click (action-> :writer/hide-peek nil), :style {:cursor :pointer, :margin-left 8}}
    (comp-android-icon :close))))

--- a/src/app/comp/repl_page.cljs
+++ b/src/app/comp/repl_page.cljs
@@ -72,7 +72,8 @@
                   :font-size 12,
                   :font-family ui/font-code,
                   :white-space :pre-line,
-                  :padding "16px 0"})}
+                  :padding "16px 0",
+                  :user-select :text})}
         (->> (:logs data)
              (sort-by (fn [[k log]] (- 0 (:time log))))
              (map-val (fn [log] (div {} (<> (:text log))))))))

--- a/src/app/comp/repl_page.cljs
+++ b/src/app/comp/repl_page.cljs
@@ -16,7 +16,7 @@
  comp-repl-page
  (states router)
  (let [data (:data router)
-       state (or (:data states) {:port nil, :code "", :build-id "client"})]
+       state (or (:data states) {:port nil, :code "", :build-id "client", :ns "cljs.user"})]
    (div
     {:style (merge ui/column {:padding "0 16px"})}
     (if (:alive? data)
@@ -25,20 +25,29 @@
        (div
         {}
         (input
-         {:style (merge style/input {:width 400}),
+         {:style (merge style/input {:width 160}),
+          :value (:ns state),
+          :on-input (mutation-> (assoc state :ns (:value %e))),
+          :placeholder "ns"})
+        (=< 8 nil)
+        (input
+         {:style (merge style/input {:width 320}),
           :value (:code state),
           :on-input (mutation-> (assoc state :code (:value %e))),
           :on-keydown (fn [e d! m!]
-            (if (= keycode/return (:key-code e)) (d! :effect/send-code (:code state)))),
+            (if (= keycode/return (:key-code e))
+              (d! :effect/send-code {:code (:code state), :ns (:ns state)}))),
           :placeholder "Clojure(Script) code to run"})
         (=< 8 nil)
         (a
          {:style style/link,
-          :on-click (action-> :effect/send-code (str "(println " (:code state) ")"))}
+          :on-click (action->
+                     :effect/send-code
+                     {:code (str "(println " (:code state) ")"), :ns (:ns state)})}
          (<> "Run"))
         (=< 8 nil)
         (a {:style style/link, :on-click (action-> :repl/clear-logs nil)} (<> "Clear"))
-        (=< 8 nil)
+        (=< 48 nil)
         (input
          {:style (merge style/input {:width 120}),
           :value (:build-id state),
@@ -48,7 +57,7 @@
         (a
          {:style style/link,
           :on-click (action-> :effect/cljs-repl (keyword (:build-id state)))}
-         (<> "Connect to runtime"))
+         (<> "Connect runtime"))
         (=< 8 nil)
         (a
          {:style (merge style/link), :on-click (action-> :effect/end-repl nil)}

--- a/src/app/repl.cljs
+++ b/src/app/repl.cljs
@@ -65,10 +65,10 @@
         (doseq [x (butlast result)] (handle-data! x))
         (println "Unknown state:" (pr-str (last result)))))))
 
-(defn send-raw-code! [code dispatch!]
-  (let [client @*repl-instance]
+(defn send-raw-code! [op-data dispatch!]
+  (let [code (:code op-data), eval-ns (:ns op-data), client @*repl-instance]
     (if (some? client)
-      (do (.eval client code "app.main" @*repl-session (on-eval-result dispatch!)))
+      (do (.eval client code eval-ns @*repl-session (on-eval-result dispatch!)))
       (dispatch! :notify/push-message [:warning "REPL not connected"]))))
 
 (defn eval-tree! [db dispatch! sid]
@@ -79,7 +79,7 @@
         code (sepal/make-string cirru-piece)]
     (println "code to eval:" code)
     (dispatch! :repl/log (str "eval code: " code))
-    (send-raw-code! (str code "\n") dispatch!)))
+    (send-raw-code! {:code (str code "\n"), :ns (:ns bookmark)} dispatch!)))
 
 (defn try-cljs-repl! [dispatch! build-id]
   (let [client @*repl-instance, repl-api (str "(shadow.cljs.devtools.api/repl " build-id ")")]

--- a/yarn.lock
+++ b/yarn.lock
@@ -369,10 +369,10 @@ date-now@^0.1.4:
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
   integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
-dayjs@^1.8.8:
-  version "1.8.8"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.8.tgz#81c81a8bb2488ef859f6c9bead9b62d649072bfd"
-  integrity sha512-qBY3kVAVJMxzS4e7DAwZZ/SSiO/DBXbvc/qqbyf1FbsZrxBq81QPdUEWhiPu8Fragf5RfHsLwtH8kCGwKL4qLQ==
+dayjs@^1.8.9:
+  version "1.8.9"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.9.tgz#8b5fda2f995ff5f29705894e1d23240f7f674f61"
+  integrity sha512-/LPzoQ77NiXf566p5babPBkqegpJ94koAQ0vUfkcfWYcuvzOTgr+N9V4IOnQ3H05Su/9dpFNOV1iPvEhAsRscw==
 
 debug@2.6.9, debug@^2.2.0:
   version "2.6.9"
@@ -1683,10 +1683,10 @@ ws@^3.0.0:
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
-ws@^6.1.4:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.4.tgz#5b5c8800afab925e94ccb29d153c8d02c1776ef9"
-  integrity sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==
+ws@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.0.tgz#13806d9913b2a5f3cbb9ba47b563c002cbc7c526"
+  integrity sha512-deZYUNlt2O4buFCa3t5bKLf8A7FPP/TVjwOeVNpw818Ma5nk4MLXls2eoEGS39o8119QIYxTrTDoPQ5B/gTD6w==
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
`ns` field is on the left, which enables sending namespace along side with code. When evaled in a tree, the namespace of the tree will be used.

![image](https://user-images.githubusercontent.com/449224/53901553-2b68ff80-407a-11e9-814a-87b56152879d.png)
