### PR TITLE
add delay in watcher processing; alpha release

### DIFF
--- a/calcit.edn
+++ b/calcit.edn
@@ -1,6 +1,6 @@
 {
  :users {
-  "S1lNv50FW" {:id "S1lNv50FW", :name "chen", :nickname "chen", :password "d41d8cd98f00b204e9800998ecf8427e", :avatar nil, :theme :curves}
+  "S1lNv50FW" {:id "S1lNv50FW", :name "chen", :nickname "chen", :password "d41d8cd98f00b204e9800998ecf8427e", :avatar nil, :theme :star-trail}
   "root" {:id "root", :name "root", :nickname "root", :password "d41d8cd98f00b204e9800998ecf8427e", :avatar nil, :theme :star-trail}
  }
  :ir {
@@ -28930,6 +28930,7 @@
             "T" {:type :leaf, :by "root", :at 1546170911195, :text "[]", :id "aQdjLW5vVE"}
             "j" {:type :leaf, :by "root", :at 1546170917708, :text "unix-time!", :id "2IOeaTIxW3"}
             "r" {:type :leaf, :by "root", :at 1546170919968, :text "id!", :id "QANyVjQ4T"}
+            "v" {:type :leaf, :by "S1lNv50FW", :at 1563645802652, :text "delay!", :id "gs9158F2Dw"}
            }
           }
          }
@@ -30695,8 +30696,10 @@
                       }
                      }
                      "r" {
-                      :type :expr, :author "SJhrjuzlG", :time 1512708406483, :id "BylA4F5DWz"
+                      :type :expr, :by "S1lNv50FW", :at 1563645805800, :id "IxtU7mHk3"
                       :data {
+                       "D" {:type :leaf, :by "S1lNv50FW", :at 1563645809761, :text "delay!", :id "ob7bAbiZyp"}
+                       "L" {:type :leaf, :by "S1lNv50FW", :at 1563645997892, :text "20", :id "-92at6of87"}
                        "T" {:type :leaf, :author "SJhrjuzlG", :time 1512708413653, :text "on-file-change!", :id "BylA4F5DWzleaf"}
                       }
                      }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calcit-editor",
-  "version": "0.4.8",
+  "version": "0.4.9-a1",
   "description": "Cirru Calcit Editor",
   "bin": {
     "calcit-editor": "dist/server.js",

--- a/src/app/server.cljs
+++ b/src/app/server.cljs
@@ -24,7 +24,7 @@
             [app.util.env :refer [check-version!]]
             [app.config :as config]
             [cumulo-util.file :refer [write-mildly! merge-local-edn!]]
-            [cumulo-util.core :refer [unix-time! id!]]
+            [cumulo-util.core :refer [unix-time! id! delay!]]
             [app.util.env :refer [get-cli-configs!]])
   (:require-macros [clojure.core.strint :refer [<<]]))
 
@@ -139,7 +139,7 @@
       (fn [error watcher]
         (if (some? error)
           (.log js/console error)
-          (.on ^js watcher "changed" (fn [filepath] (on-file-change!)))))))))
+          (.on ^js watcher "changed" (fn [filepath] (delay! 20 on-file-change!)))))))))
 
 (defn start-server! [configs]
   (pick-port!


### PR DESCRIPTION
Editor constantly read incomplete files today when pulling updates from GitHub. Trying if the problem can be solved by adding a delay and wait.
