### PR TITLE
url-parse as real dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "feather-icons": "^4.25.0",
     "http-server": "^0.12.1",
     "shadow-cljs": "^2.8.83",
-    "source-map-support": "^0.5.16",
-    "url-parse": "^1.4.7"
+    "source-map-support": "^0.5.16"
   },
   "dependencies": {
     "chalk": "^3.0.0",
@@ -39,6 +38,7 @@
     "nrepl-client": "^0.3.0",
     "serve-index": "^1.9.1",
     "shortid": "^2.2.15",
+    "url-parse": "^1.4.7",
     "ws": "^7.2.1"
   }
 }


### PR DESCRIPTION
I tried globally installing calcit-editor via npm: 
```bash
$ sudo npm i -g calcit-editor
/usr/bin/calcit-editor -> /usr/lib/node_modules/calcit-editor/dist/server.js
/usr/bin/ce -> /usr/lib/node_modules/calcit-editor/dist/server.js
+ calcit-editor@0.5.5
added 120 packages from 77 contributors in 7.769s
$ calcit-editor
internal/modules/cjs/loader.js:983
  throw err;
  ^

Error: Cannot find module 'url-parse'
Require stack:
- /usr/lib/node_modules/calcit-editor/dist/server.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:980:15)
    at Function.Module._load (internal/modules/cjs/loader.js:862:27)
    at Module.require (internal/modules/cjs/loader.js:1040:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at /usr/lib/node_modules/calcit-editor/dist/server.js:693:542
    at Object.<anonymous> (/usr/lib/node_modules/calcit-editor/dist/server.js:757:3)
    at Module._compile (internal/modules/cjs/loader.js:1151:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1171:10)
    at Module.load (internal/modules/cjs/loader.js:1000:32)
    at Function.Module._load (internal/modules/cjs/loader.js:899:14) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/usr/lib/node_modules/calcit-editor/dist/server.js' ]
}
$ sudo npm i -g url-parse
+ url-parse@1.4.7
added 3 packages from 1 contributor in 0.644s
$ calcit-editor
Using default schema.
port 6001 is ok, please edit on http://calcit-editor.cirru.org?port=6001
Running latest version 0.5.5
client connected: geaHQ6-Z
```
So, I suppose `url-parse` needs to be shifted to the (non-dev) dependencies.

Also note that [according to npm](https://docs.npmjs.com/configuring-npm/package-lock-json.html), 
>This file is intended to be committed into source repositories ...

-- but that's of course up to you!

Very interesting project :)