### PR TITLE
refine color to make highlights of collaborating editing ns/defs more obvious

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -32605,7 +32605,7 @@
                           |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1516291606295) (:text |hsl) (:id |rkm6GLB0NG)
                           |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1516291606630) (:text |0) (:id |rkfAGUrCEM)
                           |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1516291606842) (:text |0) (:id |Hkxym8SANG)
-                          |v $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1516291718932) (:text |80) (:id |rJMyQUSANz)
+                          |v $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1590769736318) (:text |74) (:id |rJMyQUSANz)
           |style-list $ {} (:type :expr) (:id |BJvXiqSKV39Z) (:by nil) (:at 1504777353661)
             :data $ {}
               |T $ {} (:type :leaf) (:text |def) (:id |SJuQj5StE3qb) (:by |root) (:at 1504777353661)
@@ -32658,12 +32658,6 @@
                                   |r $ {} (:type :expr) (:by |S1lNv50FW) (:at 1580484511761)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1580484511761) (:text |if) (:id |7lkO6mw6cU)
-                                      |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1580484511761)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1580484511761) (:text |contains?) (:id |dTS7APYGFd)
-                                          |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1580484511761) (:text |ns-highlights) (:id |8UBlsND7SN)
-                                          |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1580484511761) (:text |ns-text) (:id |M9GMZ5alx5)
-                                        :id |pP8HXSMg1_
                                       |r $ {} (:type :expr) (:by |S1lNv50FW) (:at 1580484511761)
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1580484511761) (:text |{}) (:id |r4xb2mxsOF)
@@ -32673,6 +32667,7 @@
                                               |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1580484511761) (:text |:white) (:id |n19-9jcaDp)
                                             :id |lECqCbwbLz
                                         :id |5MG3MIt6FP
+                                      |f $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1590769762741) (:text |has-highlight?) (:id |qGL3iIF4E4)
                                     :id |my2wR37xWK
                                 :id |9plyYtx6Bk
                             :id |a7mtkiEaEO
@@ -32729,13 +32724,25 @@
                                       |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1580528295484)
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1580528296848) (:text |:color) (:id |_Y_3hD0ff)
-                                          |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1580528297167)
+                                          |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1590769773447)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1580528297613) (:text |hsl) (:id |wEI4YFPAq)
-                                              |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1580528298088) (:text |0) (:id |vZuV249fR)
-                                              |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1580528298526) (:text |0) (:id |P064iyTfo)
-                                              |v $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1580528336424) (:text |50) (:id |rPzr2_Co5)
-                                            :id |pcfYORdx
+                                              |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1580528297167)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1580528297613) (:text |hsl) (:id |wEI4YFPAq)
+                                                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1580528298088) (:text |0) (:id |vZuV249fR)
+                                                  |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1580528298526) (:text |0) (:id |P064iyTfo)
+                                                  |v $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1580528336424) (:text |50) (:id |rPzr2_Co5)
+                                                :id |pcfYORdx
+                                              |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1590769774099) (:text |if) (:id |rmyQdIf6xB)
+                                              |L $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1590769776131) (:text |has-highlight?) (:id |x38MRYeN_7)
+                                              |P $ {} (:type :expr) (:by |S1lNv50FW) (:at 1590769779042)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1590769779042) (:text |hsl) (:id |CpeQdh8dQP)
+                                                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1590769779042) (:text |0) (:id |hqLDUIYTk8)
+                                                  |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1590769779042) (:text |0) (:id |mG6qvzDP-j)
+                                                  |v $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1590769810025) (:text |76) (:id |jwQdsx6rWE)
+                                                :id |oNYSSWkNqm
+                                            :id |WAmJncWjyZ
                                         :id |BVWHGFhHL
                                     :id |vXx9vP6o
                                 :id |TWm_PiqV
@@ -32865,6 +32872,16 @@
                                 :id |fu2XZkuGYG
                             :id |OMbiGlrpvG
                         :id |I6I9tNcDrp
+                      |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1590769765677)
+                        :data $ {}
+                          |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1590769766350)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1590769766350) (:text |contains?) (:id |uEJRN2gTQe)
+                              |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1590769766350) (:text |ns-highlights) (:id |0rfn6FtoNG)
+                              |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1590769766350) (:text |ns-text) (:id |BAV24qz7-2)
+                            :id |6IoFLk61DR
+                          |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1590769769451) (:text |has-highlight?) (:id |ljlywFPYER)
+                        :id |GRazLPHFz
                     :id |3RoADhScaD
                 :id |ogK5Qhruph
               |n $ {} (:type :expr) (:by |S1lNv50FW) (:at 1580484517949)
@@ -33134,7 +33151,7 @@
                           |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1516291755816) (:text |hsl) (:id |HyfMn8rRNG)
                           |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1516291756052) (:text |0) (:id |BJlN3LBRVG)
                           |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1516291756272) (:text |0) (:id |rkGE2UB0EG)
-                          |v $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1516291757129) (:text |80) (:id |SyB3UHANM)
+                          |v $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1590769872208) (:text |74) (:id |SyB3UHANM)
           |style-remove $ {} (:type :expr) (:id |SJgi2cSKE29b) (:by nil) (:at 1504777353661)
             :data $ {}
               |T $ {} (:type :leaf) (:text |def) (:id |SJWi39BYVhq-) (:by |root) (:at 1504777353661)

--- a/src/app/comp/page_files.cljs
+++ b/src/app/comp/page_files.cljs
@@ -20,7 +20,7 @@
    {:value :cljc, :display "cljc"}
    {:value :clj, :display "clj"}])
 
-(def style-def {:padding "0 8px", :position :relative, :color (hsl 0 0 80)})
+(def style-def {:padding "0 8px", :position :relative, :color (hsl 0 0 74)})
 
 (def style-file {:width 280, :overflow :auto, :padding-bottom 120})
 
@@ -142,22 +142,25 @@
    :vertical-align :middle,
    :position :relative,
    :padding "0 8px",
-   :color (hsl 0 0 80)})
+   :color (hsl 0 0 74)})
 
 (defcomp
  comp-ns-entry
  (states ns-text selected? ns-highlights)
  (let [plugin-rm-ns (use-confirm
                      (>> states :rm-ns)
-                     {:text (<< "Sure to remove namespace: ~{ns-text} ?")})]
+                     {:text (<< "Sure to remove namespace: ~{ns-text} ?")})
+       has-highlight? (contains? ns-highlights ns-text)]
    (div
     {:class-name (if selected? "hoverable is-selected" "hoverable"),
-     :style (merge style-ns (if (contains? ns-highlights ns-text) {:color :white})),
+     :style (merge style-ns (if has-highlight? {:color :white})),
      :on-click (fn [e d!] (d! :session/select-ns ns-text))}
     (let [pieces (string/split ns-text ".")]
       (span
        {}
-       (<> (str (string/join "." (butlast pieces)) ".") {:color (hsl 0 0 50)})
+       (<>
+        (str (string/join "." (butlast pieces)) ".")
+        {:color (if has-highlight? (hsl 0 0 76) (hsl 0 0 50))})
        (<> (last pieces))))
     (span
      {:class-name "is-minor",


### PR DESCRIPTION
Then ns/def is editing by another client, it will be highlighted with a brighter color. Now color is more obvious:

![image](https://user-images.githubusercontent.com/449224/83283065-2a873500-a20d-11ea-8061-9fe629a6e447.png)
