### PR TITLE
improve compact mode usages in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,17 @@ ui=local calcit-editor
 
 ### Compact output
 
+```bash
+compact=true caclcit-editor
+```
+
 When `:compact-output? true` is specified in `calcit.cirru`, "Compact Mode" is activated. Clojure(Script) will no longer be emitted,
 instead two files will be emitted:
 
 * `compact.cirru` contains a compact version of data tree of the program.
 * `.compact-inc.cirru` contains diff information from latest modification of per definition.
 
-It's not useful for Clojure but would can be used for other experiments.
+It's not useful for Clojure but would can be used for other experiments in [calcit-runner](https://github.com/Cirru/calcit-runner.nim).
 
 ### Workflow
 

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -21124,6 +21124,18 @@
                                   |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1564893022200) (:text |j/get)
                                   |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1564893022708) (:text |env)
                                   |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1564893024642) (:text |:ui)
+                      |v $ {} (:type :expr) (:by |S1lNv50FW) (:at 1602477474534)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602477477470) (:text |:compact?)
+                          |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1602477478298)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602477506615) (:text |=)
+                              |r $ {} (:type :expr) (:by |S1lNv50FW) (:at 1602477486282)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602477486282) (:text |j/get)
+                                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602477486282) (:text |env)
+                                  |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602483239003) (:text |:compact)
+                              |f $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602477507957) (:text "|\"true")
           |pick-port! $ {} (:type :expr) (:by |root) (:at 1518923396797)
             :data $ {}
               |T $ {} (:type :leaf) (:by |root) (:at 1518923396797) (:text |defn)
@@ -35945,6 +35957,13 @@
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1574589548293) (:text |fs/existsSync)
                                   |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1574589657016) (:text |storage-file)
+                          |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1602483306338)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602483306338) (:text |configs)
+                              |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1602483306338)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602483306338) (:text |:configs)
+                                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602483306338) (:text |schema/database)
                       |r $ {} (:type :expr) (:by |S1lNv50FW) (:at 1574590397606)
                         :data $ {}
                           |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1574590398181) (:text |if)
@@ -36014,7 +36033,30 @@
                                           |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1575786573708) (:text |cost)
                                           |v $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1575786585471) (:text "|\"ms to load.")
                               |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1575786590234) (:text |data)
-                          |v $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1574589630218) (:text |nil)
+                          |v $ {} (:type :expr) (:by |S1lNv50FW) (:at 1602483317302)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1602483041012)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602483042043) (:text |{})
+                                  |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1602483042462)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602483043957) (:text |:configs)
+                                      |b $ {} (:type :expr) (:by |S1lNv50FW) (:at 1602483327452)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602483327452) (:text |assoc)
+                                          |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602483327452) (:text |configs)
+                                          |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602483327452) (:text |:compact-output?)
+                                          |v $ {} (:type :expr) (:by |S1lNv50FW) (:at 1602483327452)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602483327452) (:text |:compact?)
+                                              |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1602483327452)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602483327452) (:text |get-cli-configs!)
+                              |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602483317891) (:text |if)
+                              |L $ {} (:type :expr) (:by |S1lNv50FW) (:at 1602483318195)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602483319119) (:text |some?)
+                                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602483323017) (:text |configs)
           |serve-app! $ {} (:type :expr) (:by |root) (:at 1508168225892)
             :data $ {}
               |T $ {} (:type :leaf) (:by |root) (:at 1508168225892) (:text |defn)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calcit-editor",
-  "version": "0.5.18-a1",
+  "version": "0.5.18-a2",
   "description": "Cirru Calcit Editor",
   "bin": {
     "calcit-editor": "dist/server.js",

--- a/src/app/server.cljs
+++ b/src/app/server.cljs
@@ -38,7 +38,7 @@
 (defonce initial-db
   (merge
    schema/database
-   (let [found? (fs/existsSync storage-file)]
+   (let [found? (fs/existsSync storage-file), configs (:configs schema/database)]
      (if found?
        (println (.gray chalk "Loading calcit.cirru"))
        (println (.yellow chalk "Using default schema.")))
@@ -48,7 +48,8 @@
              cost (- (unix-time!) started-at)]
          (println (chalk/gray (str "Took " cost "ms to load.")))
          data)
-       nil))))
+       (if (some? configs)
+         {:configs (assoc configs :compact-output? (:compact? (get-cli-configs!)))})))))
 
 (defonce *writer-db
   (atom

--- a/src/app/util/env.cljs
+++ b/src/app/util/env.cljs
@@ -23,7 +23,9 @@
 
 (defn get-cli-configs! []
   (let [env js/process.env]
-    {:compile? (= "compile" (j/get env :op)), :local-ui? (= "local" (j/get env :ui))}))
+    {:compile? (= "compile" (j/get env :op)),
+     :local-ui? (= "local" (j/get env :ui)),
+     :compact? (= "true" (j/get env :compact))}))
 
 (defn pick-port! [port next-fn]
   (port-taken?


### PR DESCRIPTION
Now compact mode can be specified in CLI argument, at first initialization:

```bash
compact=true ce
```