### PR TITLE
tiny refactor to render long simple expression in block

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -16216,7 +16216,7 @@
                   |j $ {} (:type :leaf) (:text |has-others?) (:by |S1lNv50FW) (:at 1511370400765)
                   |r $ {} (:type :leaf) (:text |focused?) (:by |S1lNv50FW) (:at 1511368433837)
                   |v $ {} (:type :leaf) (:text |tail?) (:by |S1lNv50FW) (:at 1511368444208)
-                  |x $ {} (:type :leaf) (:text |after-expr?) (:by |S1lNv50FW) (:at 1511368447768)
+                  |x $ {} (:type :leaf) (:text |layout-mode) (:by |S1lNv50FW) (:at 1612600150602)
                   |yT $ {} (:type :leaf) (:text |length) (:by |root) (:at 1540405517142)
                   |yb $ {} (:type :leaf) (:text |depth) (:by |S1lNv50FW) (:at 1511456054078)
                   |yj $ {} (:type :leaf) (:text |theme) (:by |S1lNv50FW) (:at 1511455554068)
@@ -16234,7 +16234,7 @@
                           |v $ {} (:type :leaf) (:text |has-others?) (:by |S1lNv50FW) (:at 1511370400765)
                           |x $ {} (:type :leaf) (:text |focused?) (:by |S1lNv50FW) (:at 1511368433837)
                           |y $ {} (:type :leaf) (:text |tail?) (:by |S1lNv50FW) (:at 1511368444208)
-                          |yT $ {} (:type :leaf) (:text |after-expr?) (:by |S1lNv50FW) (:at 1511368447768)
+                          |yT $ {} (:type :leaf) (:text |layout-mode) (:by |S1lNv50FW) (:at 1612600147004)
                           |yr $ {} (:type :leaf) (:text |length) (:by |S1lNv50FW) (:at 1511369243478)
                           |yv $ {} (:type :leaf) (:text |depth) (:by |S1lNv50FW) (:at 1511456057098)
                   |u $ {} (:type :expr) (:by |S1lNv50FW) (:at 1511455664920)
@@ -16247,7 +16247,7 @@
                           |v $ {} (:type :leaf) (:text |has-others?) (:by |S1lNv50FW) (:at 1511370400765)
                           |x $ {} (:type :leaf) (:text |focused?) (:by |S1lNv50FW) (:at 1511368433837)
                           |y $ {} (:type :leaf) (:text |tail?) (:by |S1lNv50FW) (:at 1511368444208)
-                          |yT $ {} (:type :leaf) (:text |after-expr?) (:by |S1lNv50FW) (:at 1511368447768)
+                          |yT $ {} (:type :leaf) (:text |layout-mode) (:by |S1lNv50FW) (:at 1612600143669)
                           |yr $ {} (:type :leaf) (:text |length) (:by |S1lNv50FW) (:at 1511369243478)
                           |yv $ {} (:type :leaf) (:text |depth) (:by |S1lNv50FW) (:at 1511456057098)
                   |uT $ {} (:type :expr) (:by |root) (:at 1540404659030)
@@ -16260,7 +16260,7 @@
                           |r $ {} (:type :leaf) (:by |root) (:at 1540404859722) (:text |has-others?)
                           |v $ {} (:type :leaf) (:by |root) (:at 1540404859722) (:text |focused?)
                           |x $ {} (:type :leaf) (:by |root) (:at 1540404859722) (:text |tail?)
-                          |y $ {} (:type :leaf) (:by |root) (:at 1540404859722) (:text |after-expr?)
+                          |y $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612600140610) (:text |layout-mode)
                           |yj $ {} (:type :leaf) (:by |root) (:at 1540404859722) (:text |length)
                           |yr $ {} (:type :leaf) (:by |root) (:at 1540404859722) (:text |depth)
                   |v $ {} (:type :expr) (:by |S1lNv50FW) (:at 1511455653388)
@@ -16662,15 +16662,6 @@
                       :data $ {}
                         |T $ {} (:type :leaf) (:text |[]) (:by |S1lNv50FW) (:at 1511369100908)
                         |j $ {} (:type :leaf) (:text |text-width*) (:by |S1lNv50FW) (:at 1511369105894)
-                |y $ {} (:type :expr) (:by |S1lNv50FW) (:at 1511369114940)
-                  :data $ {}
-                    |T $ {} (:type :leaf) (:text |[]) (:by |S1lNv50FW) (:at 1511369115335)
-                    |j $ {} (:type :leaf) (:text |app.client-util) (:by |S1lNv50FW) (:at 1511369117767)
-                    |r $ {} (:type :leaf) (:text |:refer) (:by |S1lNv50FW) (:at 1511369118976)
-                    |v $ {} (:type :expr) (:by |S1lNv50FW) (:at 1511369119219)
-                      :data $ {}
-                        |T $ {} (:type :leaf) (:text |[]) (:by |S1lNv50FW) (:at 1511369119888)
-                        |j $ {} (:type :leaf) (:text |simple?) (:by |S1lNv50FW) (:at 1511369121607)
                 |yT $ {} (:type :expr) (:by |root) (:at 1528996996825)
                   :data $ {}
                     |T $ {} (:type :leaf) (:by |root) (:at 1528996997226) (:text |[])
@@ -17033,7 +17024,7 @@
                   |j $ {} (:type :leaf) (:text |has-others?) (:by |S1lNv50FW) (:at 1511370400765)
                   |r $ {} (:type :leaf) (:text |focused?) (:by |S1lNv50FW) (:at 1511368433837)
                   |v $ {} (:type :leaf) (:text |tail?) (:by |S1lNv50FW) (:at 1511368444208)
-                  |x $ {} (:type :leaf) (:text |after-expr?) (:by |S1lNv50FW) (:at 1511368447768)
+                  |x $ {} (:type :leaf) (:text |layout-mode) (:by |S1lNv50FW) (:at 1612602183021)
                   |yT $ {} (:type :leaf) (:text |length) (:by |S1lNv50FW) (:at 1511369243478)
                   |yj $ {} (:type :leaf) (:text |depth) (:by |S1lNv50FW) (:at 1511456060334)
               |v $ {} (:type :expr) (:by nil) (:at 1504777353661)
@@ -17082,22 +17073,19 @@
                       |j $ {} (:type :expr) (:by nil) (:at 1504777353661)
                         :data $ {}
                           |T $ {} (:type :leaf) (:text |and) (:by |root) (:at 1504777353661)
-                          |j $ {} (:type :expr) (:by nil) (:at 1504777353661)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:text |simple?) (:by |root) (:at 1504777353661)
-                              |j $ {} (:type :leaf) (:text |expr) (:by |root) (:at 1504777353661)
                           |r $ {} (:type :expr) (:by nil) (:at 1504777353661)
                             :data $ {}
                               |T $ {} (:type :leaf) (:text |not) (:by |root) (:at 1504777353661)
                               |j $ {} (:type :leaf) (:text |tail?) (:by |root) (:at 1504777353661)
                           |v $ {} (:type :expr) (:by nil) (:at 1504777353661)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:text |not) (:by |root) (:at 1504777353661)
-                              |j $ {} (:type :leaf) (:text |after-expr?) (:by |root) (:at 1504777353661)
-                          |x $ {} (:type :expr) (:by nil) (:at 1504777353661)
+                              |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612600426509) (:text |=)
+                              |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602184420) (:text |layout-mode)
+                              |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602202766) (:text |:inline)
+                          |f $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602214090)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:text |pos?) (:by |root) (:at 1504777353661)
-                              |j $ {} (:type :leaf) (:text |length) (:by |S1lNv50FW) (:at 1511369239160)
+                              |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602214090) (:text |pos?)
+                              |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602214090) (:text |length)
                       |r $ {} (:type :leaf) (:text |style-expr-simple) (:by |S1lNv50FW) (:at 1511368496107)
                   |y $ {} (:type :expr) (:by nil) (:at 1504777353661)
                     :data $ {}
@@ -18858,7 +18846,6 @@
                       :data $ {}
                         |T $ {} (:type :leaf) (:text |[]) (:by |root) (:at 1504777353661)
                         |j $ {} (:type :leaf) (:text |coord-contains?) (:by |root) (:at 1504777353661)
-                        |r $ {} (:type :leaf) (:text |simple?) (:by |root) (:at 1504777353661)
                         |v $ {} (:type :leaf) (:text |leaf?) (:by |root) (:at 1504777353661)
                         |x $ {} (:type :leaf) (:text |expr?) (:by |root) (:at 1504777353661)
                         |y $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612192586357) (:text |expr-many-items?)
@@ -18968,7 +18955,7 @@
                 :data $ {}
                   |T $ {} (:type :leaf) (:text |states) (:by |root) (:at 1504777353661)
                   |yr $ {} (:type :leaf) (:text |readonly?) (:by |root) (:at 1504777353661)
-                  |yT $ {} (:type :leaf) (:text |after-expr?) (:by |root) (:at 1504777353661)
+                  |yT $ {} (:type :leaf) (:text |layout-mode) (:by |S1lNv50FW) (:at 1612602159539)
                   |yt $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1590232386381) (:text |picker-mode?)
                   |j $ {} (:type :leaf) (:text |expr) (:by |root) (:at 1504777353661)
                   |x $ {} (:type :leaf) (:text |others) (:by |root) (:at 1504777353661)
@@ -19032,16 +19019,6 @@
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:text |sort-by) (:by |root) (:at 1504777353661)
                                   |j $ {} (:type :leaf) (:text |first) (:by |root) (:at 1504777353661)
-                      |x $ {} (:type :expr) (:by nil) (:at 1504777353661)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:text |default-info) (:by |root) (:at 1504777353661)
-                          |j $ {} (:type :expr) (:by nil) (:at 1504777353661)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:text |{}) (:by |root) (:at 1504777353661)
-                              |j $ {} (:type :expr) (:by nil) (:at 1504777353661)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:text |:after-expr?) (:by |root) (:at 1504777353661)
-                                  |j $ {} (:type :leaf) (:text |false) (:by |root) (:at 1504777353661)
                   |r $ {} (:type :expr) (:by nil) (:at 1504777353661)
                     :data $ {}
                       |D $ {} (:type :leaf) (:text |list->) (:by |root) (:at 1510199138820)
@@ -19085,7 +19062,7 @@
                                       |T $ {} (:type :leaf) (:text |contains?) (:by |root) (:at 1504777353661)
                                       |j $ {} (:type :leaf) (:text |others) (:by |root) (:at 1504777353661)
                                       |r $ {} (:type :leaf) (:text |coord) (:by |root) (:at 1504777353661)
-                                  |y $ {} (:type :leaf) (:text |after-expr?) (:by |S1lNv50FW) (:at 1511368462741)
+                                  |y $ {} (:type :leaf) (:text |layout-mode) (:by |S1lNv50FW) (:at 1612602155684)
                                   |yn $ {} (:type :leaf) (:text |depth) (:by |S1lNv50FW) (:at 1511456048930)
                           |x $ {} (:type :expr) (:by nil) (:at 1504777353661)
                             :data $ {}
@@ -19193,10 +19170,10 @@
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:text |children) (:by |root) (:at 1510161733916)
                                   |j $ {} (:type :leaf) (:text |sorted-children) (:by |root) (:at 1510161738799)
-                              |r $ {} (:type :expr) (:by |root) (:at 1510161740425)
+                              |r $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612600273232)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:text |info) (:by |root) (:at 1510161741092)
-                                  |j $ {} (:type :leaf) (:text |default-info) (:by |root) (:at 1510161745476)
+                                  |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602064155) (:text |prev-mode)
+                                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602006901) (:text |:inline)
                           |r $ {} (:type :expr) (:by nil) (:at 1504777353661)
                             :data $ {}
                               |T $ {} (:type :leaf) (:text |if) (:by |root) (:at 1504777353661)
@@ -19260,6 +19237,34 @@
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:text |cursor-key) (:by |root) (:at 1504777353661)
                                           |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1602471334618) (:text |k)
+                                      |x $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602058314)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602058936) (:text |mode)
+                                          |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602087570)
+                                            :data $ {}
+                                              |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602059790)
+                                                :data $ {}
+                                                  |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602070345)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602072818) (:text |=)
+                                                      |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602075019) (:text |:leaf)
+                                                      |r $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602075322)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602075990) (:text |:type)
+                                                          |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602076701) (:text |child)
+                                                  |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602454200) (:text |:inline)
+                                              |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602107935) (:text |cond)
+                                              |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602092797)
+                                                :data $ {}
+                                                  |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602095031)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602113426) (:text |expr-many-items?)
+                                                      |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602116041) (:text |child)
+                                                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602122777) (:text |:block)
+                                              |r $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602125126)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602126878) (:text |:else)
+                                                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602130965) (:text |prev-mode)
                                   |r $ {} (:type :expr) (:by nil) (:at 1504777353661)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:text |if) (:by |root) (:at 1504777353661)
@@ -19344,38 +19349,12 @@
                                                       |r $ {} (:type :leaf) (:text |comp-expr) (:by |root) (:at 1504777353661)
                                                       |y $ {} (:type :leaf) (:text |focus) (:by |root) (:at 1504777353661)
                                                       |yy $ {} (:type :leaf) (:text |readonly?) (:by |root) (:at 1504777353661)
-                                                      |yv $ {} (:type :expr) (:by nil) (:at 1504777353661)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:text |:after-expr?) (:by |root) (:at 1504777353661)
-                                                          |j $ {} (:type :leaf) (:text |info) (:by |root) (:at 1504777353661)
+                                                      |yu $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602009588) (:text |mode)
                                       |r $ {} (:type :expr) (:by nil) (:at 1504777353661)
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:text |rest) (:by |root) (:at 1504777353661)
                                           |j $ {} (:type :leaf) (:text |children) (:by |root) (:at 1504777353661)
-                                      |v $ {} (:type :expr) (:by nil) (:at 1504777353661)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:text |assoc) (:by |root) (:at 1504777353661)
-                                          |j $ {} (:type :leaf) (:text |info) (:by |root) (:at 1504777353661)
-                                          |r $ {} (:type :leaf) (:text |:after-expr?) (:by |root) (:at 1504777353661)
-                                          |v $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612192490879)
-                                            :data $ {}
-                                              |T $ {} (:type :expr) (:by nil) (:at 1504777353661)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:text |expr?) (:by |S1lNv50FW) (:at 1612192490235)
-                                                  |j $ {} (:type :leaf) (:text |child) (:by |root) (:at 1504777353661)
-                                              |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612192492811) (:text |and)
-                                              |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612192920616)
-                                                :data $ {}
-                                                  |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612192494076)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612192592294) (:text |expr-many-items?)
-                                                      |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612192519416) (:text |child)
-                                                  |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612192921661) (:text |if)
-                                                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612192929530) (:text |true)
-                                                  |r $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612192945151)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612192947904) (:text |:after-expr?)
-                                                      |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612192950813) (:text |info)
+                                      |v $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602142254) (:text |mode)
           |on-keydown $ {} (:type :expr) (:by nil) (:at 1504777353661)
             :data $ {}
               |T $ {} (:type :leaf) (:text |defn) (:by |root) (:at 1504777353661)
@@ -21031,7 +21010,7 @@
                   |j $ {} (:type :leaf) (:text |has-others?) (:by |S1lNv50FW) (:at 1511458370883)
                   |r $ {} (:type :leaf) (:text |focused?) (:by |S1lNv50FW) (:at 1511458370883)
                   |v $ {} (:type :leaf) (:text |tail?) (:by |S1lNv50FW) (:at 1511458370883)
-                  |x $ {} (:type :leaf) (:text |after-expr?) (:by |S1lNv50FW) (:at 1511458370883)
+                  |x $ {} (:type :leaf) (:text |layout-mode) (:by |S1lNv50FW) (:at 1612602178427)
                   |yT $ {} (:type :leaf) (:text |length) (:by |S1lNv50FW) (:at 1511458370883)
                   |yj $ {} (:type :leaf) (:text |depth) (:by |S1lNv50FW) (:at 1511458370883)
               |v $ {} (:type :expr) (:by |S1lNv50FW) (:at 1511458370883)
@@ -21044,7 +21023,7 @@
                       |r $ {} (:type :leaf) (:by |root) (:at 1540405377687) (:text |has-others?)
                       |v $ {} (:type :leaf) (:by |root) (:at 1540405377687) (:text |focused?)
                       |x $ {} (:type :leaf) (:by |root) (:at 1540405377687) (:text |tail?)
-                      |y $ {} (:type :leaf) (:by |root) (:at 1540405377687) (:text |after-expr?)
+                      |y $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602179867) (:text |layout-mode)
                       |yj $ {} (:type :leaf) (:by |root) (:at 1540405377687) (:text |length)
                       |yr $ {} (:type :leaf) (:by |root) (:at 1540405377687) (:text |depth)
                   |f $ {} (:type :leaf) (:by |root) (:at 1540404784767) (:text |style-expr-beginner)
@@ -29932,7 +29911,7 @@
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:text |:data) (:by |root) (:at 1504777353661)
                                   |j $ {} (:type :leaf) (:text |expr) (:by |root) (:at 1504777353661)
-                          |r $ {} (:type :leaf) (:text |6) (:by |root) (:at 1504777353661)
+                          |r $ {} (:type :leaf) (:text |6) (:by |S1lNv50FW) (:at 1612599836912)
           |expr? $ {} (:type :expr) (:by nil) (:at 1504777353661)
             :data $ {}
               |T $ {} (:type :leaf) (:text |defn) (:by |root) (:at 1504777353661)
@@ -30201,7 +30180,7 @@
                   |j $ {} (:type :leaf) (:text |has-others?) (:by |S1lNv50FW) (:at 1511458370883)
                   |r $ {} (:type :leaf) (:text |focused?) (:by |S1lNv50FW) (:at 1511458370883)
                   |v $ {} (:type :leaf) (:text |tail?) (:by |S1lNv50FW) (:at 1511458370883)
-                  |x $ {} (:type :leaf) (:text |after-expr?) (:by |S1lNv50FW) (:at 1511458370883)
+                  |x $ {} (:type :leaf) (:text |layout-mode) (:by |S1lNv50FW) (:at 1612602175427)
                   |yT $ {} (:type :leaf) (:text |length) (:by |S1lNv50FW) (:at 1511458370883)
                   |yj $ {} (:type :leaf) (:text |depth) (:by |S1lNv50FW) (:at 1511458370883)
               |v $ {} (:type :expr) (:by |S1lNv50FW) (:at 1511458370883)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -17079,9 +17079,9 @@
                               |j $ {} (:type :leaf) (:text |tail?) (:by |root) (:at 1504777353661)
                           |v $ {} (:type :expr) (:by nil) (:at 1504777353661)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612600426509) (:text |=)
+                              |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612605114032) (:text |not=)
                               |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602184420) (:text |layout-mode)
-                              |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602202766) (:text |:inline)
+                              |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612605119080) (:text |:block)
                           |f $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602214090)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602214090) (:text |pos?)
@@ -19240,31 +19240,45 @@
                                       |x $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602058314)
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602058936) (:text |mode)
-                                          |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602087570)
+                                          |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602059790)
                                             :data $ {}
-                                              |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602059790)
+                                              |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612603343869)
                                                 :data $ {}
-                                                  |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602070345)
+                                                  |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612603343869) (:text |leaf?)
+                                                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612603343869) (:text |child)
+                                              |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602454200) (:text |:inline)
+                                              |L $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604118384) (:text |if)
+                                              |v $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612604123003)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604124078) (:text |if)
+                                                  |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612604127287)
                                                     :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602072818) (:text |=)
-                                                      |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602075019) (:text |:leaf)
-                                                      |r $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602075322)
+                                                      |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604127287) (:text |expr-many-items?)
+                                                      |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604127287) (:text |child)
+                                                      |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604127287) (:text |6)
+                                                  |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604127287) (:text |:block)
+                                                  |v $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612604133417)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604133417) (:text |case)
+                                                      |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604133417) (:text |prev-mode)
+                                                      |r $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612604133417)
                                                         :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602075990) (:text |:type)
-                                                          |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602076701) (:text |child)
-                                                  |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602454200) (:text |:inline)
-                                              |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602107935) (:text |cond)
-                                              |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602092797)
-                                                :data $ {}
-                                                  |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602095031)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602113426) (:text |expr-many-items?)
-                                                      |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602116041) (:text |child)
-                                                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602122777) (:text |:block)
-                                              |r $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612602125126)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602126878) (:text |:else)
-                                                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612602130965) (:text |prev-mode)
+                                                          |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604133417) (:text |:inline)
+                                                          |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604133417) (:text |:inline-block)
+                                                      |v $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612604133417)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604133417) (:text |:inline-block)
+                                                          |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612604133417)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604133417) (:text |if)
+                                                              |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612604133417)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604133417) (:text |expr-many-items?)
+                                                                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604133417) (:text |child)
+                                                                  |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604133417) (:text |2)
+                                                              |r $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604133417) (:text |:block)
+                                                              |v $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604133417) (:text |:inline-block)
+                                                      |x $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604133417) (:text |:block)
                                   |r $ {} (:type :expr) (:by nil) (:at 1504777353661)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:text |if) (:by |root) (:at 1504777353661)
@@ -29858,60 +29872,6 @@
         :proc $ {} (:type :expr) (:by nil) (:at 1504777353661) (:data $ {})
       |app.client-util $ {}
         :defs $ {}
-          |simple? $ {} (:type :expr) (:by nil) (:at 1504777353661)
-            :data $ {}
-              |T $ {} (:type :leaf) (:text |defn) (:by |root) (:at 1504777353661)
-              |j $ {} (:type :leaf) (:text |simple?) (:by |root) (:at 1504777353661)
-              |r $ {} (:type :expr) (:by nil) (:at 1504777353661)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:text |expr) (:by |root) (:at 1504777353661)
-              |v $ {} (:type :expr) (:by |root) (:at 1517756110497)
-                :data $ {}
-                  |D $ {} (:type :leaf) (:by |root) (:at 1517756112032) (:text |let)
-                  |L $ {} (:type :expr) (:by |root) (:at 1517756113215)
-                    :data $ {}
-                      |T $ {} (:type :expr) (:by |root) (:at 1517756113496)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |root) (:at 1517756117721) (:text |leaf?)
-                          |j $ {} (:type :expr) (:by |root) (:at 1517756119432)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |root) (:at 1517756121057) (:text |fn)
-                              |j $ {} (:type :expr) (:by |root) (:at 1517756121436)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |root) (:at 1517756121726) (:text |x)
-                              |r $ {} (:type :expr) (:by |root) (:at 1517756123284)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |root) (:at 1517756124542) (:text |=)
-                                  |j $ {} (:type :leaf) (:by |root) (:at 1517756126585) (:text |:leaf)
-                                  |r $ {} (:type :expr) (:by |root) (:at 1517756127566)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |root) (:at 1517756129397) (:text |:type)
-                                      |j $ {} (:type :leaf) (:by |root) (:at 1517756129806) (:text |x)
-                  |T $ {} (:type :expr) (:by nil) (:at 1504777353661)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:text |and) (:by |root) (:at 1504777353661)
-                      |j $ {} (:type :expr) (:by nil) (:at 1504777353661)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:text |every?) (:by |root) (:at 1504777353661)
-                          |b $ {} (:type :leaf) (:by |root) (:at 1517756387696) (:text |leaf?)
-                          |r $ {} (:type :expr) (:by nil) (:at 1504777353661)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:text |vals) (:by |root) (:at 1504777353661)
-                              |j $ {} (:type :expr) (:by nil) (:at 1504777353661)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:text |:data) (:by |root) (:at 1504777353661)
-                                  |j $ {} (:type :leaf) (:text |expr) (:by |root) (:at 1504777353661)
-                      |r $ {} (:type :expr) (:by nil) (:at 1504777353661)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:text |<=) (:by |root) (:at 1504777353661)
-                          |j $ {} (:type :expr) (:by nil) (:at 1504777353661)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:text |count) (:by |root) (:at 1504777353661)
-                              |j $ {} (:type :expr) (:by nil) (:at 1504777353661)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:text |:data) (:by |root) (:at 1504777353661)
-                                  |j $ {} (:type :leaf) (:text |expr) (:by |root) (:at 1504777353661)
-                          |r $ {} (:type :leaf) (:text |6) (:by |S1lNv50FW) (:at 1612599836912)
           |expr? $ {} (:type :expr) (:by nil) (:at 1504777353661)
             :data $ {}
               |T $ {} (:type :leaf) (:text |defn) (:by |root) (:at 1504777353661)
@@ -30083,37 +30043,49 @@
               |r $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612192452678)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612192456455) (:text |x)
-              |v $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612193170843)
+                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612603418572) (:text |size)
+              |v $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612604795184)
                 :data $ {}
-                  |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612193080890)
+                  |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612193170843)
                     :data $ {}
-                      |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612192479221)
+                      |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612193080890)
                         :data $ {}
-                          |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612192472959)
+                          |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612192479221)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612192473725) (:text |count)
-                              |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193178134) (:text |d)
-                          |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612192482312) (:text |>)
-                          |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193576377) (:text |2)
-                      |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193081781) (:text |or)
-                      |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612193084416)
+                              |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612192472959)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612192473725) (:text |count)
+                                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193178134) (:text |d)
+                              |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612192482312) (:text |>)
+                              |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612603421809) (:text |size)
+                          |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193081781) (:text |or)
+                          |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612604575861)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612193084416)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193085510) (:text |some)
+                                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193088286) (:text |expr?)
+                                  |r $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612193135206)
+                                    :data $ {}
+                                      |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193136494) (:text |vals)
+                                      |b $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193179817) (:text |d)
+                              |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604578031) (:text |some?)
+                      |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193171576) (:text |let)
+                      |L $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612193172756)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193085510) (:text |some)
-                          |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193088286) (:text |expr?)
-                          |r $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612193135206)
+                          |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612193173191)
                             :data $ {}
-                              |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193136494) (:text |vals)
-                              |b $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193179817) (:text |d)
-                  |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193171576) (:text |let)
-                  |L $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612193172756)
+                              |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193171943) (:text |d)
+                              |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612193175133)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193175701) (:text |:data)
+                                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193176044) (:text |x)
+                  |D $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604796033) (:text |if)
+                  |L $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612604796952)
                     :data $ {}
-                      |T $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612193173191)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193171943) (:text |d)
-                          |j $ {} (:type :expr) (:by |S1lNv50FW) (:at 1612193175133)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193175701) (:text |:data)
-                              |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612193176044) (:text |x)
+                      |T $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604799899) (:text |expr?)
+                      |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604800536) (:text |x)
+                  |j $ {} (:type :leaf) (:by |S1lNv50FW) (:at 1612604802522) (:text |false)
         :ns $ {} (:type :expr) (:by nil) (:at 1504777353661)
           :data $ {}
             |T $ {} (:type :leaf) (:text |ns) (:by |root) (:at 1504777353661)

--- a/src/app/client_util.cljs
+++ b/src/app/client_util.cljs
@@ -10,17 +10,16 @@
 
 (defn expr? [x] (= :expr (:type x)))
 
-(defn expr-many-items? [x] (let [d (:data x)] (or (> (count d) 2) (some expr? (vals d)))))
+(defn expr-many-items? [x size]
+  (if (expr? x)
+    (let [d (:data x)] (or (> (count d) size) (some? (some expr? (vals d)))))
+    false))
 
 (defn leaf? [x] (= :leaf (:type x)))
 
 (defn parse-query! []
   (let [url-obj (url-parse js/location.href true)]
     (js->clj (.-query url-obj) :keywordize-keys true)))
-
-(defn simple? [expr]
-  (let [leaf? (fn [x] (= :leaf (:type x)))]
-    (and (every? leaf? (vals (:data expr))) (<= (count (:data expr)) 6))))
 
 (def ws-host
   (if (and (exists? js/location) (not (string/blank? (.-search js/location))))

--- a/src/app/comp/expr.cljs
+++ b/src/app/comp/expr.cljs
@@ -108,10 +108,14 @@
                                   (filter (fn [x] (coord-contains? x child-coord)))
                                   (into #{}))
               cursor-key k
-              mode (cond
-                     (= :leaf (:type child)) :inline
-                     (expr-many-items? child) :block
-                     :else prev-mode)]
+              mode (if (leaf? child)
+                     :inline
+                     (if (expr-many-items? child 6)
+                       :block
+                       (case prev-mode
+                         :inline :inline-block
+                         :inline-block (if (expr-many-items? child 2) :block :inline-block)
+                         :block)))]
           (if (nil? cursor-key) (.warn js/console "[Editor] missing cursor key" k child))
           (recur
            (conj

--- a/src/app/comp/expr.cljs
+++ b/src/app/comp/expr.cljs
@@ -7,7 +7,7 @@
             [respo.comp.space :refer [=<]]
             [keycode.core :as keycode]
             [app.comp.leaf :refer [comp-leaf]]
-            [app.client-util :refer [coord-contains? simple? leaf? expr? expr-many-items?]]
+            [app.client-util :refer [coord-contains? leaf? expr? expr-many-items?]]
             [app.util.shortcuts :refer [on-window-keydown on-paste!]]
             [app.theme :refer [decide-expr-theme]]
             [app.util :refer [tree->cirru]]
@@ -72,12 +72,11 @@
 
 (defcomp
  comp-expr
- (states expr focus coord others tail? after-expr? readonly? picker-mode? theme depth)
+ (states expr focus coord others tail? layout-mode readonly? picker-mode? theme depth)
  (let [focused? (= focus coord)
        first-id (apply min (keys (:data expr)))
        last-id (apply max (keys (:data expr)))
-       sorted-children (->> (:data expr) (sort-by first))
-       default-info {:after-expr? false}]
+       sorted-children (->> (:data expr) (sort-by first))]
    (list->
     :div
     {:tab-index 0,
@@ -87,7 +86,7 @@
              (contains? others coord)
              focused?
              tail?
-             after-expr?
+             layout-mode
              (count coord)
              depth
              theme),
@@ -100,7 +99,7 @@
           (if picker-mode?
             (do (.preventDefault (:event e)) (d! :writer/pick-node (tree->cirru expr)))
             (d! :writer/focus coord)))})}
-    (loop [result [], children sorted-children, info default-info]
+    (loop [result [], children sorted-children, prev-mode :inline]
       (if (empty? children)
         result
         (let [[k child] (first children)
@@ -108,7 +107,11 @@
               partial-others (->> others
                                   (filter (fn [x] (coord-contains? x child-coord)))
                                   (into #{}))
-              cursor-key k]
+              cursor-key k
+              mode (cond
+                     (= :leaf (:type child)) :inline
+                     (expr-many-items? child) :block
+                     :else prev-mode)]
           (if (nil? cursor-key) (.warn js/console "[Editor] missing cursor key" k child))
           (recur
            (conj
@@ -132,13 +135,10 @@
                 child-coord
                 partial-others
                 (= last-id k)
-                (:after-expr? info)
+                mode
                 readonly?
                 picker-mode?
                 theme
                 (inc depth)))])
            (rest children)
-           (assoc
-            info
-            :after-expr?
-            (and (expr? child) (if (expr-many-items? child) true (:after-expr? info)))))))))))
+           mode)))))))

--- a/src/app/theme.cljs
+++ b/src/app/theme.cljs
@@ -18,14 +18,14 @@
     :beginner beginner/style-leaf
     {}))
 
-(defn decide-expr-theme [expr has-others? focused? tail? after-expr? length depth theme]
+(defn decide-expr-theme [expr has-others? focused? tail? layout-mode length depth theme]
   (case theme
     :star-trail
-      (star-trail/decide-expr-style expr has-others? focused? tail? after-expr? length depth)
+      (star-trail/decide-expr-style expr has-others? focused? tail? layout-mode length depth)
     :curves
-      (curves/decide-expr-style expr has-others? focused? tail? after-expr? length depth)
+      (curves/decide-expr-style expr has-others? focused? tail? layout-mode length depth)
     :beginner
-      (beginner/decide-expr-style expr has-others? focused? tail? after-expr? length depth)
+      (beginner/decide-expr-style expr has-others? focused? tail? layout-mode length depth)
     {}))
 
 (defn decide-leaf-theme [text focused? first? by-other? theme]

--- a/src/app/theme/beginner.cljs
+++ b/src/app/theme/beginner.cljs
@@ -4,9 +4,9 @@
 
 (def style-expr-beginner {:outline (str "1px solid " (hsl 200 80 70 0.2))})
 
-(defn decide-expr-style [expr has-others? focused? tail? after-expr? length depth]
+(defn decide-expr-style [expr has-others? focused? tail? layout-mode length depth]
   (merge
-   (star-trail/decide-expr-style expr has-others? focused? tail? after-expr? length depth)
+   (star-trail/decide-expr-style expr has-others? focused? tail? layout-mode length depth)
    style-expr-beginner))
 
 (defn decide-leaf-style [text focused? first? by-other?]

--- a/src/app/theme/curves.cljs
+++ b/src/app/theme/curves.cljs
@@ -2,7 +2,7 @@
 (ns app.theme.curves
   (:require [app.theme.star-trail :as star-trail] [hsl.core :refer [hsl]]))
 
-(defn decide-expr-style [expr has-others? focused? tail? after-expr? length depth]
+(defn decide-expr-style [expr has-others? focused? tail? layout-mode length depth]
   (merge
    {:border-radius "16px",
     :display :inline-block,

--- a/src/app/theme/star_trail.cljs
+++ b/src/app/theme/star_trail.cljs
@@ -4,7 +4,6 @@
             [clojure.string :as string]
             [respo-ui.core :as ui]
             [polyfill.core :refer [text-width*]]
-            [app.client-util :refer [simple?]]
             [app.style :as style]))
 
 (def style-expr
@@ -53,12 +52,12 @@
 
 (def style-expr-tail {:display :inline-block, :vertical-align :top, :padding-left 10})
 
-(defn decide-expr-style [expr has-others? focused? tail? after-expr? length depth]
+(defn decide-expr-style [expr has-others? focused? tail? layout-mode length depth]
   (merge
    {}
    (if has-others? {:border-color (hsl 0 0 100 0.6)})
    (if focused? {:border-color (hsl 0 0 100 0.9)})
-   (if (and (simple? expr) (not tail?) (not after-expr?) (pos? length)) style-expr-simple)
+   (if (and (pos? length) (not tail?) (= layout-mode :inline)) style-expr-simple)
    (if tail? style-expr-tail)))
 
 (def style-big {:border-right (str "16px solid " (hsl 0 0 30))})

--- a/src/app/theme/star_trail.cljs
+++ b/src/app/theme/star_trail.cljs
@@ -57,7 +57,7 @@
    {}
    (if has-others? {:border-color (hsl 0 0 100 0.6)})
    (if focused? {:border-color (hsl 0 0 100 0.9)})
-   (if (and (pos? length) (not tail?) (= layout-mode :inline)) style-expr-simple)
+   (if (and (pos? length) (not tail?) (not= layout-mode :block)) style-expr-simple)
    (if tail? style-expr-tail)))
 
 (def style-big {:border-right (str "16px solid " (hsl 0 0 30))})


### PR DESCRIPTION
Previously:

![image](https://user-images.githubusercontent.com/449224/107114155-cbe78000-689e-11eb-986b-02efb754db27.png)

Now expression with 3 leaves enforces block mode:

![image](https://user-images.githubusercontent.com/449224/107114158-d3a72480-689e-11eb-90e0-97cc4f53ad43.png)
