### PR TITLE
It should be possible to change the protocol from ws:// to wss://

### DIFF
--- a/src/app/client_util.cljs
+++ b/src/app/client_util.cljs
@@ -26,7 +26,8 @@
     (let [query (parse-query!)]
       (js/console.log "Loading from url" query)
       (str
-       "ws://"
+       (or (:protocol query) "ws")
+       "://"
        (or (:host query) "localhost")
        ":"
        (or (:port query) (:port schema/configs))))


### PR DESCRIPTION
i was trying to use the calcit client with a backend hosted on a non-localhost domain, but it failed because it was trying to use `ws` instead of `wss`:

![Screen Shot 2022-04-10 at 23 48 47](https://user-images.githubusercontent.com/6189367/162662213-26ae75f8-1116-4dbb-a660-5875a17bc74d.png)

This PR maintains the current default while adding the ability to override the protocol to wss 